### PR TITLE
release: 1.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,149 @@
+## 1.0.0-alpha.1 (2022-11-06)
+
+
+### :package: Build
+
+* cleanup build target settings ([b809be9](https://github.com/flex-development/mlly/commit/b809be9934c6661c98bdcfd3a568e7d34c0fe445))
+* remove `src` files from distribution ([0603ebe](https://github.com/flex-development/mlly/commit/0603ebefae0002c13f7d255ff2cc20cdf4057c7e))
+* require node `>=14.16` ([cd0dda9](https://github.com/flex-development/mlly/commit/cd0dda9dfae0bd205875f34d8fd8f2022e36d303))
+* **deps-dev:** bump @flex-development/mkbuild from 1.0.0-alpha.6 to 1.0.0-alpha.8 ([567bea8](https://github.com/flex-development/mlly/commit/567bea892e46be9cc04885e97a0d76235e68bd0c))
+* **deps-dev:** bump deps according to `yarn upgrade-interactive` ([e3649d4](https://github.com/flex-development/mlly/commit/e3649d4d98a59562a0ee27800eb33d1f6cc73c03))
+* **deps-dev:** bump deps according to `yarn upgrade-interactive` ([cdfc9af](https://github.com/flex-development/mlly/commit/cdfc9af3bbce508aceb0fa80d41b9de567383a14))
+* **deps-dev:** bump deps according to `yarn upgrade-interactive` ([24ee68b](https://github.com/flex-development/mlly/commit/24ee68b94523fca0ea9498068efc1765eb8f0a97))
+* **deps:** replace `pathe` with `upath` ([f705671](https://github.com/flex-development/mlly/commit/f705671f193a7c3a0d24e49e7769683b5876aeae))
+* **docs:** [site] use flex-development/docast@48367224ce9b9aa804d872071fc7e6fc6a2f38b3 ([06324f7](https://github.com/flex-development/mlly/commit/06324f723d88320e0de86563b2b78e7d3d02618c))
+* **docs:** [site] use flex-development/docast@dd4b6c3b2d4e770df99f3a2b90032f228dcd76a8 ([3de807d](https://github.com/flex-development/mlly/commit/3de807d36c5b06760c9cd8d72b98ca4b0a7233ff))
+* **pkg:** remove extraneous `bin` field ([b56c209](https://github.com/flex-development/mlly/commit/b56c2098cf328b89f8e6c34862ebc63668f9e348))
+* **syntax:** export `detectSyntax` ([4f3850f](https://github.com/flex-development/mlly/commit/4f3850f60fe9c4981337452d377f29cb6bcceb6d))
+* **syntax:** export `hasESMSyntax` ([64a89b2](https://github.com/flex-development/mlly/commit/64a89b235e8ae23c0e63fa013c110a3ca173785a))
+* **ts:** reorganize `typesVersions` ([53430fe](https://github.com/flex-development/mlly/commit/53430fe8d4e99a0792e4b64a136d8ba779d51e21))
+
+
+### :robot: Continuous Integration
+
+* add [@dependabot](https://github.com/dependabot) config ([ca31ac5](https://github.com/flex-development/mlly/commit/ca31ac58e4fcedb5feb2a86a134503ef2819fe00))
+* **deps:** bump actions/checkout from 3.0.2 to 3.1.0 ([#1](https://github.com/flex-development/mlly/issues/1)) ([a7fdf9e](https://github.com/flex-development/mlly/commit/a7fdf9e9a3d84f37e7f436a544e98692f8988cac))
+* **deps:** bump actions/github-script from 6.3.1 to 6.3.2 ([#3](https://github.com/flex-development/mlly/issues/3)) ([ef9e10d](https://github.com/flex-development/mlly/commit/ef9e10d9a08699961fee8acd664fadf8f1b95729))
+* **deps:** bump actions/github-script from 6.3.2 to 6.3.3 ([#5](https://github.com/flex-development/mlly/issues/5)) ([68306db](https://github.com/flex-development/mlly/commit/68306db8078fdcaa0a0a6ef80195335c5d7b825d))
+* **deps:** bump actions/setup-node from 3.5.0 to 3.5.1 ([#6](https://github.com/flex-development/mlly/issues/6)) ([c303f3e](https://github.com/flex-development/mlly/commit/c303f3e592508eb73e1e7f26a64cf1d3cd5f4808))
+* **deps:** Bump crazy-max/ghaction-import-gpg from 5.1.0 to 5.2.0 ([#7](https://github.com/flex-development/mlly/issues/7)) ([e87d930](https://github.com/flex-development/mlly/commit/e87d9302e3cec93872c4ccf119aba75446839291))
+* **deps:** Bump dependabot/fetch-metadata from 1.3.4 to 1.3.5 ([#8](https://github.com/flex-development/mlly/issues/8)) ([9d64f86](https://github.com/flex-development/mlly/commit/9d64f8640e10c7795bda75b183a47ffcbc2c6586))
+* **deps:** bump hmarr/debug-action from 2.0.1 to 2.1.0 ([#2](https://github.com/flex-development/mlly/issues/2)) ([3b25af3](https://github.com/flex-development/mlly/commit/3b25af3b01d82dbf195fe5d16686063cfb6533a5))
+* **deps:** bump octokit/graphql-action from 2.2.22 to 2.2.23 ([#4](https://github.com/flex-development/mlly/issues/4)) ([93e8994](https://github.com/flex-development/mlly/commit/93e89941b7bd6c5a4539cd1770d400a216c55525))
+* **workflows:** `preview` ([2936463](https://github.com/flex-development/mlly/commit/2936463896eec04a5f5025c981d74361f0ee13df))
+* **workflows:** deploy docs to production on github release ([876e5b0](https://github.com/flex-development/mlly/commit/876e5b09fe5b8f076133d1bbd78bf02eed206036))
+* **workflows:** ensure docs preview is deployed with all `src` updates ([74bdb73](https://github.com/flex-development/mlly/commit/74bdb73a81ebf38fa606f63245140c2c437d20e3))
+
+
+### :pencil: Documentation
+
+* [`hasESMSyntax`] fix typo in `@return` description ([c9f6a85](https://github.com/flex-development/mlly/commit/c9f6a8571034c82a2ac801db62632f7fc7033efc))
+* [site] add `/api/interfaces` ([95eebeb](https://github.com/flex-development/mlly/commit/95eebeb47adc9cbf8e0dc576dbb3211fd241d432))
+* [site] add `/api/types` ([cf7f5be](https://github.com/flex-development/mlly/commit/cf7f5be2af20ee33cb6b93a2809eeaf667334d15))
+* [site] add `robots.txt` generation to postbuild tasks ([ef98b86](https://github.com/flex-development/mlly/commit/ef98b86bc3e76cf52781495a52bd7b725bdf5db2))
+* [site] add esm only warning to install guide ([19dbe66](https://github.com/flex-development/mlly/commit/19dbe662ef869d26d7ac0f5412445dd392116895))
+* [site] add google site verification ([8cd42d6](https://github.com/flex-development/mlly/commit/8cd42d6fe457cc342ca22d7130cf5572d81b6e48))
+* [site] add initial front-end checklist ([1403dc3](https://github.com/flex-development/mlly/commit/1403dc357ac8db9ee9f3308b93f7d558d48be170))
+* [site] algolia search integration ([1af849d](https://github.com/flex-development/mlly/commit/1af849d7be31c618ab6742c4a9ee2cd22038999c))
+* [site] configure google analytics ([3c244ec](https://github.com/flex-development/mlly/commit/3c244ec3294b2ff6bcd6afdaf6b3238155ee25a2))
+* [site] fix canonical url ([aea7a10](https://github.com/flex-development/mlly/commit/aea7a105d3fa928c52fc5c8a67fc20acb0c6b266))
+* [site] fix duplicate meta description ([188d914](https://github.com/flex-development/mlly/commit/188d914bbdd99683a2eeaccb2c4e0080ecba5af3))
+* [site] init `/api/` ([a5084d3](https://github.com/flex-development/mlly/commit/a5084d3b1b25b6e33b570e302b91aba41c012075))
+* [site] move search indexing to `buildEnd` hook ([4b71095](https://github.com/flex-development/mlly/commit/4b71095d3e8895dcfc9c8355e9c2286da2c5c6d5))
+* [site] prevent tab nabbing ([1929374](https://github.com/flex-development/mlly/commit/1929374cf03a52d03216d39a43e1fd94d2f75431))
+* [site] specify text directionality ([1807a41](https://github.com/flex-development/mlly/commit/1807a41f31fa1a337be2722dda5771269e121522))
+* [site] update front-end checklist ([70fd41d](https://github.com/flex-development/mlly/commit/70fd41d216b6f5d2ceb8f913ea6b87f744c15877))
+* [site]: add `/api/constants` ([ed2bb9f](https://github.com/flex-development/mlly/commit/ed2bb9f8d54525a0da49dff9c879a9831cccef2d))
+* [site]: resolve `@link` ([6ed82f8](https://github.com/flex-development/mlly/commit/6ed82f84e248a2ea21f73559fa40dba25bd88db5))
+* [site]: update `/api/` title and intro ([3e60e88](https://github.com/flex-development/mlly/commit/3e60e884b5e7f551be3621ccbb2c4dabed783f73))
+* [site]: update `/api/constants` intro ([2d1d525](https://github.com/flex-development/mlly/commit/2d1d52590e7098006f4df4c58e8d75af2ebb471a))
+* init docs site ([df39382](https://github.com/flex-development/mlly/commit/df39382d9472d3eb97eb0eca37fd147634a65ff3))
+* merge zsh docs into contributing guide ([f2e2a6c](https://github.com/flex-development/mlly/commit/f2e2a6c64d3cd8cf3376c912236deec7cfab4f37))
+* reorganize gpr install guide ([0a8ef6e](https://github.com/flex-development/mlly/commit/0a8ef6ec08490807c3727398ae402d57c4b32f3d))
+* temporarily remove `detectSyntax` example ([afc41e9](https://github.com/flex-development/mlly/commit/afc41e9d16c6f869d26db44bbac7579b24f6123c))
+* update descriptions and reference links ([8bd5702](https://github.com/flex-development/mlly/commit/8bd570288ef8ed66fce4bd24bf3bc84b9e113dd2))
+
+
+### :sparkles: Features
+
+* **analyze:** `extractStatements` ([08b9124](https://github.com/flex-development/mlly/commit/08b9124a76e5c4aa182221d87dea903b3876efd4))
+* **analyze:** `findDynamicImports` ([a03089a](https://github.com/flex-development/mlly/commit/a03089a6ab374adaa1c0908bf304677f11e8b8e2))
+* **analyze:** `findExports` ([7a66d78](https://github.com/flex-development/mlly/commit/7a66d781caa6d5f522d4a51e345eafb16b48974e))
+* **analyze:** `findRequires` ([1d58008](https://github.com/flex-development/mlly/commit/1d58008174cc0622c2b1a54ce0dbd8741553cacc))
+* **analyze:** `findStaticImports` ([673294c](https://github.com/flex-development/mlly/commit/673294cae8156f26538f7f1db51efcab74678fcc))
+* **interfaces:** `CompilerOptionsJson` ([39c1abf](https://github.com/flex-development/mlly/commit/39c1abf9856886566277f771eddf27d3cb6aabd6))
+* **interfaces:** `DynamicImport` ([b7474a1](https://github.com/flex-development/mlly/commit/b7474a18e482bd74f9c1337c78adc3299d2b0be5))
+* **interfaces:** `ExportStatement` ([4384be4](https://github.com/flex-development/mlly/commit/4384be4525b22858e4cbcc782e5a57352583fd60))
+* **interfaces:** `ImportStatement` ([6a16d74](https://github.com/flex-development/mlly/commit/6a16d74c491ee2f0453b31a3ea4bf15b9ab62289))
+* **interfaces:** `RequireStatement` ([0dc6d7a](https://github.com/flex-development/mlly/commit/0dc6d7a8cb6a4c00f20621a3232cd0b37476025b))
+* **interfaces:** `Statement` ([ec25911](https://github.com/flex-development/mlly/commit/ec25911670d0d204d196eb0039a95948ef7174c1))
+* **interfaces:** `StaticImport` ([78816b7](https://github.com/flex-development/mlly/commit/78816b748cde2eec6bbfc821370be46008e46a21))
+* **lib:** `getCompilerOptions` ([08c4b84](https://github.com/flex-development/mlly/commit/08c4b8492f7640f74dc676c073a7075115846698))
+* **lib:** `isBuiltin` ([b0a618b](https://github.com/flex-development/mlly/commit/b0a618bf910b5a135a0f44df06dffcc0b6747774))
+* **lib:** `toDataURL` ([57647dd](https://github.com/flex-development/mlly/commit/57647dd958bc29ff578c1661c3977021034ea5aa))
+* **resolve:** [`resolveModule`] `@types` detection ([bcd1de7](https://github.com/flex-development/mlly/commit/bcd1de782395a784e0536f7184072acdaef7f33e))
+* **resolve:** `resolveAlias` ([4014515](https://github.com/flex-development/mlly/commit/4014515682448d909fff777d41ed114f2a5ae072))
+* **resolve:** `resolveAliases` ([25895cf](https://github.com/flex-development/mlly/commit/25895cf8455d932973593193db50fa28ea882d29))
+* **resolve:** `resolveModule` ([90ae6b5](https://github.com/flex-development/mlly/commit/90ae6b55f197d161023119f82d394abb1d2dd5d3))
+* **resolve:** `resolveModules` ([e7394ad](https://github.com/flex-development/mlly/commit/e7394ad44ce4965ff2d14ee4a7a7d61a23a7be1e))
+* **specifiers:** [`toBareSpecifier`] `@types` detection + `types` entry point support ([6991fae](https://github.com/flex-development/mlly/commit/6991fae7631aa0f2ceb0c3c120349b7d5de55e0e))
+* **specifiers:** `toAbsoluteSpecifier` ([83578ac](https://github.com/flex-development/mlly/commit/83578ac87e2600ad1cb7751a260667a13aac77f4))
+* **specifiers:** `toBareSpecifier` ([1407d5e](https://github.com/flex-development/mlly/commit/1407d5e059442fec95bd017aa4f8853856cd3166))
+* **specifiers:** `toRelativeSpecifier` ([26b7096](https://github.com/flex-development/mlly/commit/26b70967a8d2c06b2449b79002d2ebf7a7bbb990))
+* **syntax:** `detectSyntax` ([184950f](https://github.com/flex-development/mlly/commit/184950faba5ee78597b69a2e4b1219338ff56bc7))
+* **syntax:** `hasCJSSyntax` ([7d64e65](https://github.com/flex-development/mlly/commit/7d64e657002e4fd6ace32775bb2c274574765781))
+* **syntax:** `hasESMSyntax` ([6888620](https://github.com/flex-development/mlly/commit/688862056a14d0ddd633d74cc9708b07b6fc2922))
+* **syntax:** detect dynamic imports in commonjs ([05b4d8f](https://github.com/flex-development/mlly/commit/05b4d8f69302d7d6c991bc4dd12a874b0947ca34))
+* **types:** `Declaration` ([1427995](https://github.com/flex-development/mlly/commit/1427995fd8999090fd76ae59adb6ecbadf19e263))
+* **types:** `Ext` ([2ccd483](https://github.com/flex-development/mlly/commit/2ccd4832690367959ba207df0378409a1d4ee2ab))
+* **types:** `MIMEType` ([8ff6a94](https://github.com/flex-development/mlly/commit/8ff6a944207b32f45eddda8a7fd6ac38bf47f634))
+* **types:** `SpecifierType` ([6feccb1](https://github.com/flex-development/mlly/commit/6feccb15fca8affeb51efd6ce78f4ae267056910))
+* **types:** `StatementType` ([b0feb6c](https://github.com/flex-development/mlly/commit/b0feb6cbf79b5a2d5364b728a2f2a45b8c6f5a50))
+
+
+### :bug: Fixes
+
+* **docs:** [site] sitemap urls ([95cfad6](https://github.com/flex-development/mlly/commit/95cfad6e10d047d8d9d3bf8ffa0620f50c47472d))
+* **internal:** `STATIC_IMPORT_REGEX` matches `:` in ternary statements ([d2027f8](https://github.com/flex-development/mlly/commit/d2027f83515065a28992d6d91ee3e22b2062c1d1))
+* **internal:** `STATIC_IMPORT_REGEX` matches `import` in module specifiers ([a58ec20](https://github.com/flex-development/mlly/commit/a58ec2055750747743bc537f32f33ad7676fdcf4))
+* **resolve:** [`resolveModules`] ignore dynamic import statements with dynamic specifiers ([48c20bd](https://github.com/flex-development/mlly/commit/48c20bd4915c16914c80e198a420485b9c8a0582))
+* **tests:** [`findDynamicImports`] dynamic specifier test ([ee1b01b](https://github.com/flex-development/mlly/commit/ee1b01b6c727b54fecf64b0142ef6409fe30c941))
+
+
+### :house_with_garden: Housekeeping
+
+* add empty changelog ([7dfb431](https://github.com/flex-development/mlly/commit/7dfb431e5f7ced07d6a9a5028347016f2dd5b4c9))
+* disable eslint rule `unicorn/no-unsafe-regex` ([8d24eda](https://github.com/flex-development/mlly/commit/8d24edada5a7c6edfee6d316239cd29dc076531c)), closes [sindresorhus/eslint-plugin-unicorn#153](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/153)
+* improve vercel integration ([1db75bc](https://github.com/flex-development/mlly/commit/1db75bc420b42652c440ec0a09742dc319c857f5))
+* update editorconfig properties ([60256a8](https://github.com/flex-development/mlly/commit/60256a822ddc721781fe6d6579459fcc9e51a2ec))
+* **docs:** scrap `vc dev` usage ([5ce8c0f](https://github.com/flex-development/mlly/commit/5ce8c0f0468b2def494922f8f3b58ebb60a5a19c)), closes [vercel/vercel#8121](https://github.com/vercel/vercel/issues/8121)
+* **github:** add commit scope `analyze` ([f3aaee9](https://github.com/flex-development/mlly/commit/f3aaee92ddbac08744d671cb7b905dbb36dba0f6))
+* **github:** add commit scope `docs` ([6111249](https://github.com/flex-development/mlly/commit/61112490c88de111f1906a4725d98abaa5c7247a))
+* **github:** add commit scope `interfaces` ([15fc6d9](https://github.com/flex-development/mlly/commit/15fc6d97ff06304710b55bf67768cb14e4ba4295))
+* **github:** add commit scope `internal` ([63c3470](https://github.com/flex-development/mlly/commit/63c34707f54d5c5dbeea0ef06d3eea3bd927d888))
+* **github:** add commit scope `specifiers` ([a7b3eb3](https://github.com/flex-development/mlly/commit/a7b3eb32b6cced07607af5be3f7c5c1240bcf3c2))
+* **github:** add commit scope `types` ([da9f588](https://github.com/flex-development/mlly/commit/da9f588beac0d8e00daa60e40739306e424a3fa7))
+* **github:** add label `scope:docs` ([6a98495](https://github.com/flex-development/mlly/commit/6a98495c6f1feabe786509c4bfc5aa6cb63573cb))
+* **github:** add label `scope:internal` ([daca7af](https://github.com/flex-development/mlly/commit/daca7afda87a3f1dd2d292ed5e06cde42b3d5929))
+* **ts:** enforce `import type` for type-only imports ([acd84b8](https://github.com/flex-development/mlly/commit/acd84b8c004fce22da9b2ea16b5281089fb5b15d))
+
+
+### :fire: Performance Improvements
+
+* **docs:** [site] improve speed of first search query ([0ad65db](https://github.com/flex-development/mlly/commit/0ad65db1a6f731f7452d40375359f7584266a5d1))
+* **docs:** [site] use exact urls to increase speed ([55c1267](https://github.com/flex-development/mlly/commit/55c1267864fe9540c38cd8e5bc970a855cd497bf))
+
+
+### :zap: Refactors
+
+* **docs:** [site] comments compilation ([f66861c](https://github.com/flex-development/mlly/commit/f66861c9dca4e2f17403d8bc5684c2f120d4ebaa))
+* **interfaces:** `AliasResolverOptions` -> `ResolveAliasOptions` ([602d11a](https://github.com/flex-development/mlly/commit/602d11a71c6ee288e7f73454a49cfdaaa5e71cc5))
+* **internal:** add internals ([7a486c7](https://github.com/flex-development/mlly/commit/7a486c7ed3c84f39b0b4b7143f92729ce7912d81))
+* **lib:** move `getCompilerOptions` to `internal` ([7c5656d](https://github.com/flex-development/mlly/commit/7c5656d70bd67c18a9c126abb6e84ff838552ad8))
+* **lib:** replace `isBuiltin` with `@flex-development/is-builtin` ([c868cec](https://github.com/flex-development/mlly/commit/c868cec9b5fce91014b1666b3f9aceef60acf079))
+* **resolve:** [`resolveAliases`] signature ([190fb52](https://github.com/flex-development/mlly/commit/190fb5260adb4559beaf0f3666c68b1cc1a16094))
+* **resolve:** [options] allow readonly arrays ([6df4a4b](https://github.com/flex-development/mlly/commit/6df4a4bb3836adef0b6f15884575edb6ce78c2a0))
+* **resolve:** [options] pass original module specifier to `ext` ([4615851](https://github.com/flex-development/mlly/commit/46158510fdd0e3d8e0e60757290a655606ad836e))
+* **resolve:** sort `RESOLVE_EXTENSIONS` according to priority ([0266ca9](https://github.com/flex-development/mlly/commit/0266ca9a5593d0c66e950ba1fe2c8f6df8422ff9))
+* **specifiers:** [`toBareSpecifier`] improve `exports` path search ([36c4b74](https://github.com/flex-development/mlly/commit/36c4b7475c9bb6c924f5e75c8d6d215a8d23e79c))
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/mlly",
   "description": "ECMAScript module utilities",
-  "version": "0.0.0",
+  "version": "1.0.0-alpha.1",
   "keywords": [
     "esm",
     "module",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,15 +4,17 @@
 
 # 1. run tests
 # 2. build project
-# 3. get new package version
-# 4. get release branch name
-# 5. switch to release branch
-# 6. stage changes
-# 7. commit changes
-# 8. push release branch to origin
+# 3. build docs
+# 4. get new package version
+# 5. get release branch name
+# 6. switch to release branch
+# 7. stage changes
+# 8. commit changes
+# 9. push release branch to origin
 
 yarn test:cov
 yarn build
+yarn docs:build
 VERSION=$(jq .version package.json -r)
 RELEASE_BRANCH=release/$VERSION
 git switch -c $RELEASE_BRANCH

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,6 @@
     "plugins": [{ "name": "@vuedx/typescript-plugin-vue" }],
     "preserveConstEnums": true,
     "preserveSymlinks": true,
-    "preserveValueImports": true,
     "pretty": true,
     "resolveJsonModule": true,
     "rootDir": ".",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.0.0-alpha.1`
- added `CHANGELOG` entry for `1.0.0-alpha.1`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.24.5
      Coverage enabled with c8

 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export abstract class
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export async function
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export class
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export const
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export default
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export enum
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export function
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export interface
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export let
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export type
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export var
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should ignore declaration export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should ignore declaration export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > default > should detect default export
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > default > should ignore default export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > default > should ignore default export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should detect named export
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should detect named exports spanning multiple lines
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should ignore named export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should ignore named export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > star > should detect star export
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > star > should ignore star export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > star > should ignore star export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > default > should detect default import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > default > should ignore default import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > default > should ignore default import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > dynamic > should detect dynamic import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > dynamic > should ignore dynamic import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > dynamic > should ignore dynamic import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should detect named import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should detect named imports spanning multiple lines
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should ignore named import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should ignore named import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > star > should detect star import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > star > should ignore star import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > star > should ignore star import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should detect import.meta.env
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should detect import.meta.env property
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should ignore import.meta.env in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should ignore import.meta.env in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > resolve > should detect import.meta.resolve
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > resolve > should ignore import.meta.resolve in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > resolve > should ignore import.meta.resolve in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > url > should detect import.meta.url
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > url > should ignore import.meta.url in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > url > should ignore import.meta.url in single-line comment
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should find default static import
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should find default type import
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should find named static imports in multi-line statement
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should find named static imports in single-line statement
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should find named type imports in multi-line statement
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should find named type imports in single-line statement
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should find star static import
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should ignore static import in multi-line comment
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should ignore static import in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __dirname > should detect __dirname
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __dirname > should ignore __dirname in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __dirname > should ignore __dirname in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __filename > should detect __filename
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __filename > should ignore __filename in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __filename > should ignore __filename in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > await import > should detect await import
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > await import > should ignore await import in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > await import > should ignore await import in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should detect default export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should detect named export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore default export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore default export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore named export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore named export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should detect default export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should detect named export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore default export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore default export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore named export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore named export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should detect require statement
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should detect require.resolve statement
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require statement in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require statement in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require.resolve statement in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require.resolve statement in single-line comment
 ✓ src/lib/__tests__/detect-syntax.spec.ts > unit:lib/detectSyntax > should return cjs-only syntax result
 ✓ src/lib/__tests__/detect-syntax.spec.ts > unit:lib/detectSyntax > should return esm-only syntax result
 ✓ src/lib/__tests__/detect-syntax.spec.ts > unit:lib/detectSyntax > should return mixed syntax result
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require > should find require
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require > should find require declaration
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require > should find require with named imports
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require > should find require with named imports in multi-line statement
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require > should ignore require in multi-line comment
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require > should ignore require in single-line comment
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require.resolve > should find require.resolve
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require.resolve > should find require.resolve declaration
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require.resolve > should ignore require.resolve in multi-line comment
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > require.resolve > should ignore require.resolve in single-line comment
 ✓ src/internal/__tests__/get-compiler-options.spec.ts > unit:internal/getCompilerOptions > should return empty object is tsconfig is not found
 ✓ src/internal/__tests__/get-compiler-options.spec.ts > unit:internal/getCompilerOptions > should return empty object if user options are not found
 ✓ src/internal/__tests__/get-compiler-options.spec.ts > unit:internal/getCompilerOptions > should return user options
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert alias from unknown parent to absolute specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert current directory alias to relative specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert module alias to relative specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert node_modules alias to bare specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert outer directory alias to relative specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should return specifier if path match was not found
 ✓ src/lib/__tests__/extract-statements.functional.spec.ts > functional:lib/extractStatements > should exit early if no code to evaluate
 ✓ src/lib/__tests__/extract-statements.functional.spec.ts > functional:lib/extractStatements > should extract statements from code
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find dynamic import
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find dynamic import with dynamic specifier
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find dynamic import declaration
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find dynamic import declaration with dynamic specifier
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find dynamic import declaration without await
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find named dynamic imports in multi-line statement
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find named dynamic imports in single-line statement
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should find transpiled dynamic import
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should ignore dynamic import in multi-line comment
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should ignore dynamic import in single-line comment
 ✓ src/lib/__tests__/resolve-alias.functional.spec.ts > functional:lib/resolveAlias > should load tsconfig file
 ✓ src/lib/__tests__/resolve-alias.functional.spec.ts > functional:lib/resolveAlias > should use baseUrl and paths from tsconfig
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > abstract class > should find export abstract class
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > abstract class > should find export declare abstract class
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > abstract class > should ignore export abstract class in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > abstract class > should ignore export abstract class in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function > should find export async function
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function > should find export declare async function
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function > should ignore export async function in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function > should ignore export async function in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function* > should find export async function*
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function* > should find export declare async function*
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function* > should ignore export async function* in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > async function* > should ignore export async function* in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > class > should find export class
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > class > should find export declare class
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > class > should ignore export class in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > class > should ignore export class in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const > should find export const
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const > should find export declare const
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const > should ignore export const in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const > should ignore export const in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const enum > should find export const enum
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const enum > should find export declare const enum
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const enum > should ignore export const enum in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > const enum > should ignore export const enum in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default > should find export default
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default > should find export default if anonymous
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default > should ignore export default in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default > should ignore export default in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async > should find export default async
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async > should ignore export default async in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async > should ignore export default async in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function > should find export default async function
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function > should find export default async function if anonymous
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function > should ignore default async function in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function > should ignore default async function in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function* > should find export default async function*
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function* > should find export default async function* if anonymous
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function* > should ignore default async function* in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default async function* > should ignore default async function* in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function > should find export default function
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function > should find export default function if anonymous
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function > should ignore export default function in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function > should ignore export default function in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function* > should find export default function*
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function* > should find export default function* if anonymous
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function* > should ignore default function* in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > default function* > should ignore default function* in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > enum > should find export enum
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > enum > should find export declare enum
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > enum > should ignore export enum in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > enum > should ignore export enum in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function > should find export function
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function > should find export declare function
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function > should ignore export function in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function > should ignore export function in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function* > should find export function*
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function* > should find export declare function*
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function* > should ignore export function* in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > function* > should ignore export function* in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > interface > should find export interface
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > interface > should find export declare interface
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > interface > should ignore export interface in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > interface > should ignore export interface in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > let > should find export let
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > let > should find export declare let
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > let > should ignore export let in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > let > should ignore export let in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > namespace > should find export namespace
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > namespace > should find export declare namespace
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > namespace > should ignore export namespace in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > namespace > should ignore export namespace in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > type > should find export type
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > type > should find export declare type
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > type > should ignore export type in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > type > should ignore export type in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > var > should find export var
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > var > should find export declare var
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > var > should ignore export var in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > declaration > var > should ignore export var in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > named > should find named exports in multi-line statement
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > named > should find named exports in single-line statement
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > named > should find named type exports in multi-line statement
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > named > should find named type exports in single-line statement
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > named > should ignore named exports in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > named > should ignore named exports in single-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > star > should find star export
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > star > should find star export with alias
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > star > should ignore star export in multi-line comment
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > star > should ignore star export in single-line comment
 ✓ src/lib/__tests__/resolve-aliases.functional.spec.ts > functional:lib/resolveAliases > should do nothing if no path aliases are found
 ✓ src/lib/__tests__/resolve-aliases.functional.spec.ts > functional:lib/resolveAliases > should resolve path aliases in code
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if cwd is file url
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if cwd is string
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if specifier is file url
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if specifier is string
 ✓ src/lib/__tests__/to-relative-specifier.spec.ts > unit:lib/toRelativeSpecifier > should return specifier relative from current directory
 ✓ src/lib/__tests__/to-relative-specifier.spec.ts > unit:lib/toRelativeSpecifier > should return specifier relative from outer directory
 ✓ src/lib/__tests__/to-data-url.spec.ts > unit:lib/toDataURL > should return javascript data url
 ✓ src/lib/__tests__/to-data-url.spec.ts > unit:lib/toDataURL > should return json data url
 ✓ src/lib/__tests__/to-data-url.spec.ts > unit:lib/toDataURL > should return wasm data url
 ✓ src/lib/__tests__/resolve-modules.functional.spec.ts > functional:lib/resolveModules > should do nothing if module specifier is missing
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve data url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve file url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve file url as directory index w/o /index*
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve file url w/o extension
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve http url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve https url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve node builtin w/o node protocol
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve node url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve module
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve module as directory index w/o /index*
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve module w/o extension
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should throw if intolerable error is encountered
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should throw if module could not be resolved
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return bare specifier
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier with replaced extension
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier w/o /index*
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier w/o extension
 ✓ src/lib/__tests__/resolve-modules.functional.spec.ts > functional:lib/resolveModules > should resolve modules in code
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > should exit early if specifier is node builtin
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > should return pkg name w/o scope if @types is detected
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > should throw ERR_INVALID_PACKAGE_CONFIG if package.json is not found
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return pkg name if specifier is exports
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return pkg name if specifier is exports w/o ext
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return pkg name if specifier is pkg name
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return specifier as bare specifier
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should throw ERR_PACKAGE_PATH_NOT_EXPORTED if subpath export is not found
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return pkg name if specifier is main
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return pkg name if specifier is main w/o ext
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return pkg name if specifier is pkg name
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return specifier as bare specifier

Test Files  18 passed (18)
     Tests  250 passed (250)
  Start at  03:52:21
  Duration  10.59s (transform 624ms, setup 13.76s, collect 4.97s, tests 561ms)

 % Coverage report from c8
---------------------------|---------|----------|---------|---------|-------------------
File                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------------------|---------|----------|---------|---------|-------------------
All files                  |     100 |      100 |     100 |     100 |                   
 src                       |     100 |      100 |     100 |     100 |                   
  constants.ts             |     100 |      100 |     100 |     100 |                   
 src/internal              |     100 |      100 |     100 |     100 |                   
  constants.ts             |     100 |      100 |     100 |     100 |                   
  get-compiler-options.ts  |     100 |      100 |     100 |     100 |                   
 src/lib                   |     100 |      100 |     100 |     100 |                   
  detect-syntax.ts         |     100 |      100 |     100 |     100 |                   
  extract-statements.ts    |     100 |      100 |     100 |     100 |                   
  find-dynamic-imports.ts  |     100 |      100 |     100 |     100 |                   
  find-exports.ts          |     100 |      100 |     100 |     100 |                   
  find-requires.ts         |     100 |      100 |     100 |     100 |                   
  find-static-imports.ts   |     100 |      100 |     100 |     100 |                   
  has-cjs-syntax.ts        |     100 |      100 |     100 |     100 |                   
  has-esm-syntax.ts        |     100 |      100 |     100 |     100 |                   
  resolve-alias.ts         |     100 |      100 |     100 |     100 |                   
  resolve-aliases.ts       |     100 |      100 |     100 |     100 |                   
  resolve-module.ts        |     100 |      100 |     100 |     100 |                   
  resolve-modules.ts       |     100 |      100 |     100 |     100 |                   
  to-absolute-specifier.ts |     100 |      100 |     100 |     100 |                   
  to-bare-specifier.ts     |     100 |      100 |     100 |     100 |                   
  to-data-url.ts           |     100 |      100 |     100 |     100 |                   
  to-relative-specifier.ts |     100 |      100 |     100 |     100 |                   
---------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/mlly                                                                   03:56:01
✔ Build succeeded for @flex-development/mlly                                                        03:56:06
  dist (total size: 48.3 kB)                                                                        03:56:06
  └─ dist/constants.mjs (332 B)
  └─ dist/constants.d.mts (456 B)
  └─ dist/index.mjs (107 B)
  └─ dist/index.d.mts (160 B)
  └─ dist/interfaces/import-dynamic.mjs (0 B)
  └─ dist/interfaces/import-dynamic.d.mts (508 B)
  └─ dist/interfaces/import-static.mjs (0 B)
  └─ dist/interfaces/import-static.d.mts (434 B)
  └─ dist/interfaces/index.mjs (0 B)
  └─ dist/interfaces/index.d.mts (601 B)
  └─ dist/interfaces/options-resolve-alias.mjs (0 B)
  └─ dist/interfaces/options-resolve-alias.d.mts (1.83 kB)
  └─ dist/interfaces/options-resolve.mjs (0 B)
  └─ dist/interfaces/options-resolve.d.mts (1.64 kB)
  └─ dist/interfaces/statement-export.mjs (0 B)
  └─ dist/interfaces/statement-export.d.mts (691 B)
  └─ dist/interfaces/statement-import.mjs (0 B)
  └─ dist/interfaces/statement-import.d.mts (573 B)
  └─ dist/interfaces/statement-require.mjs (0 B)
  └─ dist/interfaces/statement-require.d.mts (547 B)
  └─ dist/interfaces/statement.mjs (0 B)
  └─ dist/interfaces/statement.d.mts (653 B)
  └─ dist/internal/compiler-options-json.mjs (0 B)
  └─ dist/internal/compiler-options-json.d.mts (6.06 kB)
  └─ dist/internal/constants.mjs (2.01 kB)
  └─ dist/internal/constants.d.mts (1.36 kB)
  └─ dist/internal/get-compiler-options.mjs (431 B)
  └─ dist/internal/get-compiler-options.d.mts (803 B)
  └─ dist/internal/index.mjs (136 B)
  └─ dist/internal/index.d.mts (232 B)
  └─ dist/lib/detect-syntax.mjs (325 B)
  └─ dist/lib/detect-syntax.d.mts (504 B)
  └─ dist/lib/extract-statements.mjs (509 B)
  └─ dist/lib/extract-statements.d.mts (600 B)
  └─ dist/lib/find-dynamic-imports.mjs (762 B)
  └─ dist/lib/find-dynamic-imports.d.mts (458 B)
  └─ dist/lib/find-exports.mjs (1.65 kB)
  └─ dist/lib/find-exports.d.mts (422 B)
  └─ dist/lib/find-requires.mjs (673 B)
  └─ dist/lib/find-requires.d.mts (462 B)
  └─ dist/lib/find-static-imports.mjs (772 B)
  └─ dist/lib/find-static-imports.d.mts (448 B)
  └─ dist/lib/has-cjs-syntax.mjs (204 B)
  └─ dist/lib/has-cjs-syntax.d.mts (501 B)
  └─ dist/lib/has-esm-syntax.mjs (204 B)
  └─ dist/lib/has-esm-syntax.d.mts (505 B)
  └─ dist/lib/index.mjs (1.43 kB)
  └─ dist/lib/index.d.mts (1.06 kB)
  └─ dist/lib/resolve-alias.mjs (1.15 kB)
  └─ dist/lib/resolve-alias.d.mts (698 B)
  └─ dist/lib/resolve-aliases.mjs (1.01 kB)
  └─ dist/lib/resolve-aliases.d.mts (552 B)
  └─ dist/lib/resolve-module.mjs (2.34 kB)
  └─ dist/lib/resolve-module.d.mts (1.03 kB)
  └─ dist/lib/resolve-modules.mjs (910 B)
  └─ dist/lib/resolve-modules.d.mts (543 B)
  └─ dist/lib/to-absolute-specifier.mjs (700 B)
  └─ dist/lib/to-absolute-specifier.d.mts (706 B)
  └─ dist/lib/to-bare-specifier.mjs (2.45 kB)
  └─ dist/lib/to-bare-specifier.d.mts (857 B)
  └─ dist/lib/to-data-url.mjs (213 B)
  └─ dist/lib/to-data-url.d.mts (889 B)
  └─ dist/lib/to-relative-specifier.mjs (594 B)
  └─ dist/lib/to-relative-specifier.d.mts (699 B)
  └─ dist/types/declaration.mjs (0 B)
  └─ dist/types/declaration.d.mts (495 B)
  └─ dist/types/ext.mjs (0 B)
  └─ dist/types/ext.d.mts (163 B)
  └─ dist/types/index.mjs (0 B)
  └─ dist/types/index.d.mts (350 B)
  └─ dist/types/mime-type.mjs (0 B)
  └─ dist/types/mime-type.d.mts (291 B)
  └─ dist/types/specifier-type.mjs (0 B)
  └─ dist/types/specifier-type.d.mts (281 B)
  └─ dist/types/statement-type.mjs (0 B)
  └─ dist/types/statement-type.d.mts (292 B)
Σ Total build size: 48.3 kB                                                                         03:56:06
```

### `yarn docs:build`

```zsh
vitepress v1.0.0-alpha.27
✓ building client + server bundles...
✓ rendering pages...
build complete in 7.31s.
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/mlly/blob/main/CONTRIBUTING.md#pull-request-titles
