### PR TITLE
fix(specifiers): `toRelativeSpecifier` logic

### DIFF
--- a/src/lib/__tests__/to-relative-specifier.spec.ts
+++ b/src/lib/__tests__/to-relative-specifier.spec.ts
@@ -3,26 +3,27 @@
  * @module mlly/lib/tests/toRelativeSpecifier/unit
  */
 
-import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import testSubject from '../to-relative-specifier'
 
 describe('unit:lib/toRelativeSpecifier', () => {
-  it('should return specifier relative from current directory', () => {
+  it('should return relative specifier', () => {
     // Arrange
-    const specifier = pathToFileURL('src/interfaces')
-    const parent = path.resolve('src/index.ts')
+    const cases: [...Parameters<typeof testSubject>, string][] = [
+      ['src/interfaces', 'src', './interfaces'],
+      ['src/interfaces', 'src/index.ts', './interfaces'],
+      ['src/types', 'src/types/ext.ts', '.'],
+      ['src/types/index.ts', 'src/types/ext.ts', './index.ts'],
+      [
+        pathToFileURL('dist/types/parent.mjs'),
+        pathToFileURL('dist/lib/to-relative-specifier.mjs'),
+        '../types/parent.mjs'
+      ]
+    ]
 
     // Act + Expect
-    expect(testSubject(specifier, parent)).to.equal('./interfaces')
-  })
-
-  it('should return specifier relative from outer directory', () => {
-    // Arrange
-    const specifier = path.resolve('dist/types/parent.mjs')
-    const parent = pathToFileURL('dist/lib/to-relative-specifier.mjs')
-
-    // Act + Expect
-    expect(testSubject(specifier, parent)).to.equal('../types/parent.mjs')
+    cases.forEach(([specifier, parent, expected]) => {
+      expect(testSubject(specifier, parent)).to.equal(expected)
+    })
   })
 })

--- a/src/lib/to-relative-specifier.ts
+++ b/src/lib/to-relative-specifier.ts
@@ -33,9 +33,17 @@ const toRelativeSpecifier = (
   if (parent.startsWith('file:')) parent = fileURLToPath(parent)
   if (specifier.startsWith('file:')) specifier = fileURLToPath(specifier)
 
-  return pathe
-    .relative(pathe.dirname(parent), specifier)
+  // convert specifier to relative specifier
+  specifier = pathe
+    .relative(pathe.resolve(parent), pathe.resolve(specifier))
+    .replace(/^\.\.\/?/, '')
     .replace(/^(\w)/, './$1')
+
+  // set specifier to dot character if empty string
+  // this occurs when specifier is a directory, but is not fully specified
+  if (!specifier) specifier = '.'
+
+  return specifier
 }
 
 export default toRelativeSpecifier


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

fixed `toRelativeSpecifier` logic.

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test`

```zsh
RUN  v0.26.2
      Coverage enabled with c8

 ✓ src/enums/__tests__/kind-specifier.spec-d.ts > unit-d:enums/SpecifierKind > should match [DYNAMIC = "dynamic"]
 ✓ src/enums/__tests__/kind-specifier.spec-d.ts > unit-d:enums/SpecifierKind > should match [STATIC = "static"]
 ✓ src/enums/__tests__/kind-statement.spec-d.ts > unit-d:enums/StatementKind > should match [EXPORT = "export"]
 ✓ src/enums/__tests__/kind-statement.spec-d.ts > unit-d:enums/StatementKind > should match [IMPORT = "import"]
 ✓ src/enums/__tests__/kind-statement.spec-d.ts > unit-d:enums/StatementKind > should match [REQUIRE = "require"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [DECLARATION = "declaration"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [DEFAULT = "default"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [DEFAULT_WITH_NAMED = "default-with-named"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [DEFAULT_WITH_NAMESPACE = "default-with-namespace"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [DYNAMIC = "dynamic"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [LIST = "list"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [NAMED = "named"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [NAMESPACE = "namespace"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [REQUIRE = "require"]
 ✓ src/enums/__tests__/kind-syntax.spec-d.ts > unit-d:enums/SyntaxKind > should match [SIDE_EFFECT = "side-effect"]
 ✓ src/interfaces/__tests__/import-dynamic.spec-d.ts > unit-d:interfaces/DynamicImport > should extend ImportStatement
 ✓ src/interfaces/__tests__/import-dynamic.spec-d.ts > unit-d:interfaces/DynamicImport > should match [expression: LiteralUnion<EmptyString, string>]
 ✓ src/interfaces/__tests__/import-dynamic.spec-d.ts > unit-d:interfaces/DynamicImport > should match [options: LiteralUnion<EmptyString, string>]
 ✓ src/interfaces/__tests__/import-dynamic.spec-d.ts > unit-d:interfaces/DynamicImport > should match [syntax: Extract<SyntaxKindImport, SyntaxKind.DYNAMIC>]
 ✓ src/interfaces/__tests__/import-static.spec-d.ts > unit-d:interfaces/StaticImport > should extend ImportStatement
 ✓ src/interfaces/__tests__/import-static.spec-d.ts > unit-d:interfaces/StaticImport > should match [assertion: LiteralUnion<EmptyString, string>]
 ✓ src/interfaces/__tests__/import-static.spec-d.ts > unit-d:interfaces/StaticImport > should match [syntax: Omit<SyntaxKindImport, SyntaxKind.DYNAMIC>]
 ✓ src/interfaces/__tests__/import-static.spec-d.ts > unit-d:interfaces/StaticImport > should match [type: boolean]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [baseUrl?: string]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [extensions?: string[] | readonly string[]]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [fileExists?(this: void, path: string): boolean]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [mainFields?: OneOrMany<string>[]]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [parent?: string]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [paths?: Record<string, string[]>]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [readFile?(this: void, filename: string): string]
 ✓ src/interfaces/__tests__/options-resolve-alias.spec-d.ts > unit-d:interfaces/ResolveAliasOptions > should match [tsconfig?: string]
 ✓ src/interfaces/__tests__/options-resolve.spec-d.ts > unit-d:interfaces/ResolveOptions > should match [conditions?: Set<string> | string[] | readonly string[]]
 ✓ src/interfaces/__tests__/options-resolve.spec-d.ts > unit-d:interfaces/ResolveOptions > should match [ext?: Ext | Function | false]
 ✓ src/interfaces/__tests__/options-resolve.spec-d.ts > unit-d:interfaces/ResolveOptions > should match [extensions?: string[] | readonly string[]]
 ✓ src/interfaces/__tests__/options-resolve.spec-d.ts > unit-d:interfaces/ResolveOptions > should match [parent?: URL | string]
 ✓ src/interfaces/__tests__/options-resolve.spec-d.ts > unit-d:interfaces/ResolveOptions > should match [preserveSymlinks?: boolean]
 ✓ src/interfaces/__tests__/options-resolve.spec-d.ts > unit-d:interfaces/ResolveOptions > should match [type?: Function | ModuleSpecifierType]
 ✓ src/interfaces/__tests__/statement-export.spec-d.ts > unit-d:interfaces/ExportStatement > should extend Statement
 ✓ src/interfaces/__tests__/statement-export.spec-d.ts > unit-d:interfaces/ExportStatement > should match [declaration: Nullable<Declaration>]
 ✓ src/interfaces/__tests__/statement-export.spec-d.ts > unit-d:interfaces/ExportStatement > should match [exports: string[]]
 ✓ src/interfaces/__tests__/statement-export.spec-d.ts > unit-d:interfaces/ExportStatement > should match [kind: StatementKind.EXPORT]
 ✓ src/interfaces/__tests__/statement-export.spec-d.ts > unit-d:interfaces/ExportStatement > should match [modifiers: string[]]
 ✓ src/interfaces/__tests__/statement-export.spec-d.ts > unit-d:interfaces/ExportStatement > should match [syntax: SyntaxKindExport]
 ✓ src/interfaces/__tests__/statement-export.spec-d.ts > unit-d:interfaces/ExportStatement > should match [type: boolean]
 ✓ src/interfaces/__tests__/statement-import.spec-d.ts > unit-d:interfaces/ImportStatement > should extend Statement
 ✓ src/interfaces/__tests__/statement-import.spec-d.ts > unit-d:interfaces/ImportStatement > should match [imports: string[]]
 ✓ src/interfaces/__tests__/statement-import.spec-d.ts > unit-d:interfaces/ImportStatement > should match [kind: StatementKind.IMPORT]
 ✓ src/interfaces/__tests__/statement-import.spec-d.ts > unit-d:interfaces/ImportStatement > should match [specifier: string]
 ✓ src/interfaces/__tests__/statement-import.spec-d.ts > unit-d:interfaces/ImportStatement > should match [specifier_kind: SpecifierKind]
 ✓ src/interfaces/__tests__/statement-import.spec-d.ts > unit-d:interfaces/ImportStatement > should match [syntax: SyntaxKindImport]
 ✓ src/interfaces/__tests__/statement-require.spec-d.ts > unit-d:interfaces/RequireStatement > should extend Statement
 ✓ src/interfaces/__tests__/statement-require.spec-d.ts > unit-d:interfaces/RequireStatement > should match [imports: string[]]
 ✓ src/interfaces/__tests__/statement-require.spec-d.ts > unit-d:interfaces/RequireStatement > should match [kind: StatementKind.REQUIRE]
 ✓ src/interfaces/__tests__/statement-require.spec-d.ts > unit-d:interfaces/RequireStatement > should match [specifier: string]
 ✓ src/interfaces/__tests__/statement-require.spec-d.ts > unit-d:interfaces/RequireStatement > should match [specifier_kind: SpecifierKind]
 ✓ src/interfaces/__tests__/statement-require.spec-d.ts > unit-d:interfaces/RequireStatement > should match [syntax: SyntaxKindRequire]
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should be json object
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should match [code: string]
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should match [end: number]
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should match [kind: StatementKind]
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should match [specifier: Nullable<string>]
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should match [specifier_kind: Nullable<SpecifierKind>]
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should match [syntax: StatementSyntax]
 ✓ src/interfaces/__tests__/statement.spec-d.ts > unit-d:interfaces/Statement > should match [start: number]
 ✓ src/internal/__tests__/get-compiler-options.spec.ts > unit:internal/getCompilerOptions > should return empty object if tsconfig is not found
 ✓ src/internal/__tests__/get-compiler-options.spec.ts > unit:internal/getCompilerOptions > should return empty object if user options are not found
 ✓ src/internal/__tests__/get-compiler-options.spec.ts > unit:internal/getCompilerOptions > should return user options
 ✓ src/lib/__tests__/detect-syntax.spec.ts > unit:lib/detectSyntax > should return cjs-only syntax result
 ✓ src/lib/__tests__/detect-syntax.spec.ts > unit:lib/detectSyntax > should return esm-only syntax result
 ✓ src/lib/__tests__/detect-syntax.spec.ts > unit:lib/detectSyntax > should return mixed syntax result
 ✓ src/lib/__tests__/extract-statements.functional.spec.ts > functional:lib/extractStatements > should exit early if no code to evaluate
 ✓ src/lib/__tests__/extract-statements.functional.spec.ts > functional:lib/extractStatements > should extract statements from code
 ✓ src/lib/__tests__/find-dynamic-imports.spec.ts > unit:lib/findDynamicImports > should return DynamicImport object array
 ✓ src/lib/__tests__/find-exports.spec.ts > unit:lib/findExports > should return ExportStatement object array
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > should return RequireStatement object array
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > comments > should ignore require in multi-line comment
 ✓ src/lib/__tests__/find-requires.spec.ts > unit:lib/findRequires > comments > should ignore require in single-line comment
 ✓ src/lib/__tests__/find-static-imports.spec.ts > unit:lib/findStaticImports > should return StaticImport object array
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __dirname > should detect __dirname
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __dirname > should ignore __dirname in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __dirname > should ignore __dirname in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __filename > should detect __filename
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __filename > should ignore __filename in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > __filename > should ignore __filename in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > await import > should detect await import
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > await import > should ignore await import in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > await import > should ignore await import in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should detect default export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should detect named export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore default export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore default export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore named export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > exports > should ignore named export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should detect default export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should detect named export
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore default export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore default export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore named export in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > module.exports > should ignore named export in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should detect require statement
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should detect require.resolve statement
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require statement in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require statement in single-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require.resolve statement in multi-line comment
 ✓ src/lib/__tests__/has-cjs-syntax.spec.ts > unit:lib/hasCJSSyntax > require > should ignore require.resolve statement in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export abstract class
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export async function
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export class
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export const
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export default
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export enum
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export function
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export interface
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export let
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export type
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should detect declaration export var
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should ignore declaration export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > declaration > should ignore declaration export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > default > should detect default export
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > default > should ignore default export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > default > should ignore default export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should detect named export
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should detect named exports spanning multiple lines
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should ignore named export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > named > should ignore named export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > star > should detect star export
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > star > should ignore star export in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > export > star > should ignore star export in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > default > should detect default import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > default > should ignore default import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > default > should ignore default import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > dynamic > should detect dynamic import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > dynamic > should ignore dynamic import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > dynamic > should ignore dynamic import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should detect named import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should detect named imports spanning multiple lines
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should ignore named import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > named > should ignore named import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > star > should detect star import
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > star > should ignore star import in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import > star > should ignore star import in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should detect import.meta.env
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should detect import.meta.env property
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should ignore import.meta.env in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > env > should ignore import.meta.env in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > resolve > should detect import.meta.resolve
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > resolve > should ignore import.meta.resolve in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > resolve > should ignore import.meta.resolve in single-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > url > should detect import.meta.url
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > url > should ignore import.meta.url in multi-line comment
 ✓ src/lib/__tests__/has-esm-syntax.spec.ts > unit:lib/hasESMSyntax > import.meta > url > should ignore import.meta.url in single-line comment
 ✓ src/lib/__tests__/resolve-alias.functional.spec.ts > functional:lib/resolveAlias > should load tsconfig file
 ✓ src/lib/__tests__/resolve-alias.functional.spec.ts > functional:lib/resolveAlias > should use baseUrl and paths from tsconfig
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert alias from unknown parent to absolute specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert current directory alias to relative specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert module alias to relative specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert node_modules alias to bare specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should convert outer directory alias to relative specifier
 ✓ src/lib/__tests__/resolve-alias.spec.ts > unit:lib/resolveAlias > should return specifier if path match was not found
 ✓ src/lib/__tests__/resolve-aliases.functional.spec.ts > functional:lib/resolveAliases > should do nothing if no path aliases are found
 ✓ src/lib/__tests__/resolve-aliases.functional.spec.ts > functional:lib/resolveAliases > should resolve path aliases in code
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve data url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve file url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve file url as directory index w/o /index*
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve file url w/o extension
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve http url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve https url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve node builtin w/o node protocol
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve node url
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve module
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve module as directory index w/o /index*
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should resolve module w/o extension
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should throw if intolerable error is encountered
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > resolve > should throw if module could not be resolved
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return bare specifier
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier with replaced extension
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier w/o /index*
 ✓ src/lib/__tests__/resolve-module.spec.ts > unit:lib/resolveModule > type > should return relative specifier w/o extension
 ✓ src/lib/__tests__/resolve-modules.functional.spec.ts > functional:lib/resolveModules > should do nothing if module specifier is missing
 ✓ src/lib/__tests__/resolve-modules.functional.spec.ts > functional:lib/resolveModules > should resolve modules in code
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if cwd is file url
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if cwd is string
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if specifier is file url
 ✓ src/lib/__tests__/to-absolute-specifier.spec.ts > unit:lib/toAbsoluteSpecifier > should return absolute specifier if specifier is string
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > should exit early if specifier is node builtin
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > should return pkg name w/o scope if @types is detected
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > should throw ERR_INVALID_PACKAGE_CONFIG if package.json is not found
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return pkg name if specifier is exports
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return pkg name if specifier is exports w/o ext
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return pkg name if specifier is pkg name
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should return specifier as bare specifier
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > exports > should throw ERR_PACKAGE_PATH_NOT_EXPORTED if subpath export is not found
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return pkg name if specifier is main
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return pkg name if specifier is main w/o ext
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return pkg name if specifier is pkg name
 ✓ src/lib/__tests__/to-bare-specifier.spec.ts > unit:lib/toBareSpecifier > no exports > should return specifier as bare specifier
 ✓ src/lib/__tests__/to-data-url.spec.ts > unit:lib/toDataURL > should return javascript data url
 ✓ src/lib/__tests__/to-data-url.spec.ts > unit:lib/toDataURL > should return json data url
 ✓ src/lib/__tests__/to-data-url.spec.ts > unit:lib/toDataURL > should return wasm data url
 ✓ src/lib/__tests__/to-relative-specifier.spec.ts > unit:lib/toRelativeSpecifier > should return relative specifier
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "class"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "const enum"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "const"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "enum"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "function"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "function*"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "interface"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "let"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "namespace"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "type"
 ✓ src/types/__tests__/declaration.spec-d.ts > unit-d:types/Declaration > should extract "var"
 ✓ src/types/__tests__/mime-type.spec-d.ts > unit-d:types/MIMEType > should extract "application/json"
 ✓ src/types/__tests__/mime-type.spec-d.ts > unit-d:types/MIMEType > should extract "application/wasm"
 ✓ src/types/__tests__/mime-type.spec-d.ts > unit-d:types/MIMEType > should extract "text/javascript"
 ✓ src/types/__tests__/module-specifier-type.spec-d.ts > unit-d:types/ModuleSpecifierType > should extract "absolute"
 ✓ src/types/__tests__/module-specifier-type.spec-d.ts > unit-d:types/ModuleSpecifierType > should extract "bare"
 ✓ src/types/__tests__/module-specifier-type.spec-d.ts > unit-d:types/ModuleSpecifierType > should extract "relative"
 ✓ src/types/__tests__/syntax-kind-export.spec-d.ts > unit-d:types/SyntaxKindExport > should extract SyntaxKind.DECLARATION
 ✓ src/types/__tests__/syntax-kind-export.spec-d.ts > unit-d:types/SyntaxKindExport > should extract SyntaxKind.DEFAULT
 ✓ src/types/__tests__/syntax-kind-export.spec-d.ts > unit-d:types/SyntaxKindExport > should extract SyntaxKind.LIST
 ✓ src/types/__tests__/syntax-kind-export.spec-d.ts > unit-d:types/SyntaxKindExport > should extract SyntaxKind.NAMED
 ✓ src/types/__tests__/syntax-kind-export.spec-d.ts > unit-d:types/SyntaxKindExport > should extract SyntaxKind.NAMESPACE
 ✓ src/types/__tests__/syntax-kind-import.spec-d.ts > unit-d:types/SyntaxKindImport > should extract SyntaxKind.DEFAULT
 ✓ src/types/__tests__/syntax-kind-import.spec-d.ts > unit-d:types/SyntaxKindImport > should extract SyntaxKind.DEFAULT_WITH_NAMED
 ✓ src/types/__tests__/syntax-kind-import.spec-d.ts > unit-d:types/SyntaxKindImport > should extract SyntaxKind.DEFAULT_WITH_NAMESPACE
 ✓ src/types/__tests__/syntax-kind-import.spec-d.ts > unit-d:types/SyntaxKindImport > should extract SyntaxKind.DYNAMIC
 ✓ src/types/__tests__/syntax-kind-import.spec-d.ts > unit-d:types/SyntaxKindImport > should extract SyntaxKind.NAMED
 ✓ src/types/__tests__/syntax-kind-import.spec-d.ts > unit-d:types/SyntaxKindImport > should extract SyntaxKind.NAMESPACE
 ✓ src/types/__tests__/syntax-kind-import.spec-d.ts > unit-d:types/SyntaxKindImport > should extract SyntaxKind.SIDE_EFFECT
 ✓ src/types/__tests__/syntax-kind-require.spec-d.ts > unit-d:types/SyntaxKindRequire > should extract SyntaxKind.REQUIRE

 Test Files  35 passed (35)
      Tests  231 passed (231)
   Start at  20:36:27
   Duration  26.64s (transform 1.04s, setup 6.84s, collect 1.68s, tests 460ms)

 % Coverage report from c8
---------------------------|---------|----------|---------|---------|-------------------
File                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------------------|---------|----------|---------|---------|-------------------
All files                  |     100 |      100 |     100 |     100 |                   
 src                       |     100 |      100 |     100 |     100 |                   
  constants.ts             |     100 |      100 |     100 |     100 |                   
 src/enums                 |     100 |      100 |     100 |     100 |                   
  kind-specifier.ts        |     100 |      100 |     100 |     100 |                   
  kind-statement.ts        |     100 |      100 |     100 |     100 |                   
  kind-syntax.ts           |     100 |      100 |     100 |     100 |                   
 src/internal              |     100 |      100 |     100 |     100 |                   
  get-compiler-options.ts  |     100 |      100 |     100 |     100 |                   
 src/lib                   |     100 |      100 |     100 |     100 |                   
  detect-syntax.ts         |     100 |      100 |     100 |     100 |                   
  extract-statements.ts    |     100 |      100 |     100 |     100 |                   
  find-dynamic-imports.ts  |     100 |      100 |     100 |     100 |                   
  find-exports.ts          |     100 |      100 |     100 |     100 |                   
  find-requires.ts         |     100 |      100 |     100 |     100 |                   
  find-static-imports.ts   |     100 |      100 |     100 |     100 |                   
  has-cjs-syntax.ts        |     100 |      100 |     100 |     100 |                   
  has-esm-syntax.ts        |     100 |      100 |     100 |     100 |                   
  resolve-alias.ts         |     100 |      100 |     100 |     100 |                   
  resolve-aliases.ts       |     100 |      100 |     100 |     100 |                   
  resolve-module.ts        |     100 |      100 |     100 |     100 |                   
  resolve-modules.ts       |     100 |      100 |     100 |     100 |                   
  to-absolute-specifier.ts |     100 |      100 |     100 |     100 |                   
  to-bare-specifier.ts     |     100 |      100 |     100 |     100 |                   
  to-data-url.ts           |     100 |      100 |     100 |     100 |                   
  to-relative-specifier.ts |     100 |      100 |     100 |     100 |                   
---------------------------|---------|----------|---------|---------|-------------------
```

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

- fixes #26

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

- https://nodejs.org/api/esm.html#terminology

## Additional context

<!-- Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced. -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/mlly/blob/main/CONTRIBUTING.md#pull-request-titles
